### PR TITLE
Adding a section to Pre-Trained Embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,11 @@ More information can be found in [the full documentation](https://torchbiggraph.
 
 We trained a PBG model on the full [Wikidata](https://www.wikidata.org/) graph, using a [translation operator](https://torchbiggraph.readthedocs.io/en/latest/scoring.html#operators) to represent relations. It can be downloaded [here](https://dl.fbaipublicfiles.com/torchbiggraph/wikidata_translation_v1.tsv.gz) (36GiB, gzip-compressed). We used the truthy version of data from [here](https://dumps.wikimedia.org/wikidatawiki/entities/) to train our model. The model file is in TSV format as described in the above section. Note that the first line of the file contains the number of entities, the number of relations and the dimension of the embeddings, separated by tabs. The model contains 78 million entities, 4,131 relations and the dimension of the embeddings is 200.
 
+### Working with the pre-trained embeddings
+
+You can run the pre-trained embeddings directly with [Weaviate](https://github.com/semi-technologies/weaviate). You can [import them yourself](https://github.com/semi-technologies/biggraph-wikidata-search-with-weaviate), run them from a [Weaviate backup](https://github.com/semi-technologies/biggraph-wikidata-search-with-weaviate#restore-as-weaviate-backup) or [use the live service](http://biggraph-wikidata-in-weaviate.vectors.network/).
+
+
 ## Citation
 
 To cite this work please use:


### PR DESCRIPTION
Adding a section titled "Working with Pre-Trained Embeddings"  adding details on how you can run the embedding directly (and hassle free) with Weaviate.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

Q :  Why is this change required? What problem does it solve? 
A : It helps people get over the issue to running embeds easily by helping them with direct links in the read-me itself.  It contains all the starter details about how to work with and where. 

<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->
No issues or breaks so far on the Markdown. 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
